### PR TITLE
Fix Netlify 404 by auto-detecting base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ EMAIL_SMTP_PASSWORD="smtp-password"
 EOF
 
 # 3. 번들 생성 (로컬에서는 빌드 직후 gh-pages 브랜치로 자동 푸시)
+#    - Netlify 등 루트 도메인 배포 환경: `npm run build`
+#    - GitHub Pages 등 서브 디렉터리 배포: `PUBLIC_BASE_PATH=/Image-Editor-2 npm run build`
+#      (Windows PowerShell: `$env:PUBLIC_BASE_PATH="/Image-Editor-2"; npm run build`)
 npm run build
 
 # CI나 원격 환경(Netlify 등)에서 GitHub Pages 푸시를 건너뛰고 싶다면 아래처럼 실행하세요.

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,7 +66,41 @@ const injectSpaRedirect = async (filePath, basePath) => {
   }
 }
 
-const PUBLIC_BASE_PATH = '/Image-Editor-2/'
+const normalizeBasePath = (value) => {
+  if (!value) {
+    return '/'
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === '/') {
+    return '/'
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return ensureTrailingSlash(withLeadingSlash)
+}
+
+const resolvePublicBasePath = () => {
+  if (process.env.PUBLIC_BASE_PATH) {
+    return normalizeBasePath(process.env.PUBLIC_BASE_PATH)
+  }
+
+  if (process.env.NETLIFY === 'true') {
+    return '/'
+  }
+
+  const repository = process.env.GITHUB_REPOSITORY
+  if (process.env.CI === 'true' && repository) {
+    const [, repoName] = repository.split('/')
+    if (repoName) {
+      return normalizeBasePath(repoName)
+    }
+  }
+
+  return '/Image-Editor-2/'
+}
+
+const PUBLIC_BASE_PATH = resolvePublicBasePath()
 
 const serverBuildPlugin = () => {
   return {


### PR DESCRIPTION
## Summary
- normalize the Vite public base path so Netlify builds serve assets from the root and GitHub Pages keeps its subdirectory URL
- document how to override the base path for GitHub Pages builds

## Testing
- SKIP_GH_PUBLISH=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4dbc71af88325897e065c6885988d